### PR TITLE
fix: missing : in flag and missing codeblock

### DIFF
--- a/README.md
+++ b/README.md
@@ -1660,7 +1660,7 @@ High
 ``` json
 {
 "FFlagAXAccessoryAdjustmentlXPEnabledForAll": "True",
-"DFFlagUseVisBugChecks" "True",
+"DFFlagUseVisBugChecks": "True",
 "DFFlagUseVisBugChecks27": "True",
 }
 ```
@@ -1765,7 +1765,7 @@ High
 ```
 ### Self Explanatory 7
 ###### @thefrenchguy4
-```
+```json
 {
     "FFlagRenamePassesAndGearToSubscriptionsAndPasses": "False"
 }


### PR DESCRIPTION
there was a : that wasn't included in one of the fast flags, meaning importing it would cause errors.
also, there was a missing json tag in one of the codeblocks, so it ended up not looking properly formatted.