### PR TITLE
Add warning on FFlagUserRaycastPerformanceImprovements 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1453,6 +1453,7 @@ makes you go bounce, on 0 you float a little bit above the ground, always needs 
 }
 ```
 ### Raycast Performance Improvements
+## Also makes you unable to see through things such as glass, and any invisible things. Can lead to game breaking issues.
 ##### tip: Uses workspace:Raycast() instead of worldmodel:FindPartOnRayWithIgnoreList()
 ``` json
 {

--- a/README.md
+++ b/README.md
@@ -1453,7 +1453,7 @@ makes you go bounce, on 0 you float a little bit above the ground, always needs 
 }
 ```
 ### Raycast Performance Improvements
-## Also makes you unable to see through things such as glass, and any invisible things. Can lead to game breaking issues.
+Also leads to game breaking issues in some games due to not being able to see through transparent objects.
 ##### tip: Uses workspace:Raycast() instead of worldmodel:FindPartOnRayWithIgnoreList()
 ``` json
 {


### PR DESCRIPTION
Adds a warning to FFlagUserRaycastPerformanceImprovements due to flag making transparent objects non-transparent making the camera in games unable to see-through objects that should be well. Able to be seen through.

As seen on https://github.com/NoobLikesThis/roblox-fflags/issues/13#issuecomment-2596923315